### PR TITLE
Remove square brackets when resolving URL (QPE-371)

### DIFF
--- a/src/url-resolver/urlResolver.js
+++ b/src/url-resolver/urlResolver.js
@@ -68,8 +68,8 @@ if(QueryString.URL.includes("select/")){
         Sense can associate the selected value. Regardless, replace any slashes in the selected value.*/
     for(var j = 0; j<selectionsAlone.length; j++){
       selectionsAlone[j] = selectionsAlone[j]
-        .replace(/%5D/g,"]")
-        .replace(/%5B/g,"[")
+        .replace(/%5D/g,"")
+        .replace(/%5B/g,"")
         .replace(/%2F/g,"/")
         .replace(/\*/g, ''); // hack to make sure * doesn't mess up url resolution completely
 


### PR DESCRIPTION
The square brackets used forces sense into doing a search on the terms instead of simply selecting them.

Brackets are generally used in sense to handle spaces in field names, not entirely sure why the original author choose to include them here.

This might have unknown effects, but I've yet to see any. And leaving this is causes huge performance issues for any selections larger than ~10-20