### PR TITLE
Added missing installer in qext

### DIFF
--- a/src/assets/qlik-share-button.qext
+++ b/src/assets/qlik-share-button.qext
@@ -10,6 +10,7 @@
 	"keywords": "qlik-sense, visualization",
 	"license": "MIT",
 	"repository": "",
+	"installer": "QlikExtensionBundler",
 	"dependencies": {
 		"qlik-sense": ">=5.5.x"
 	},


### PR DESCRIPTION
-This was added previously, but accidentally removed
 in a revert.

-When installer isn't present the install.js will abort
 when running again because of service being restarted.